### PR TITLE
Update dependencies' versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## 0.8.5 (2023-09-16)
 
 * Update dependency versions.
 * Update coverage attribute due to `cargo-llvm-cov` upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+* Update dependency versions.
+* Update coverage attribute due to `cargo-llvm-cov` upgrade.
+
+
 ## 0.8.4 (2023-07-01)
 
 * Add `FnGraph::try_for_each_concurrent_control`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ daggy = { version = "0.8.0", default-features = false }
 fn_meta = { version = "0.7.3", optional = true, features = ["fn_meta_ext"] }
 resman = { version = "0.16.1", optional = true, features = ["debug"] }
 futures = { version = "0.3.28", optional = true }
-smallvec = "1.10.0"
-tokio = { version = "1.29.1", features = ["sync"] }
+smallvec = "1.11.0"
+tokio = { version = "1.32.0", features = ["sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.87"
 
 [dev-dependencies]
 resman = { version = "0.16.1", features = ["debug", "fn_res", "fn_res_mut", "fn_meta"] }
-tokio = { version = "1.29.1", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1.32.0", features = ["macros", "rt", "sync", "time"] }
 
 [features]
 default = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fn_graph"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Dynamically managed function graph execution."

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Add the following to `Cargo.toml`
 fn_graph = "0.8.1"
 
 # Integrate with `fn_meta` and/or `resman`
-fn_graph = { version = "0.8.4", features = ["fn_meta"] }
-fn_graph = { version = "0.8.4", features = ["resman"] }
-fn_graph = { version = "0.8.4", features = ["fn_meta", "resman"] }
+fn_graph = { version = "0.8.5", features = ["fn_meta"] }
+fn_graph = { version = "0.8.5", features = ["resman"] }
+fn_graph = { version = "0.8.5", features = ["fn_meta", "resman"] }
 ```
 
 # Rationale

--- a/src/fn_graph.rs
+++ b/src/fn_graph.rs
@@ -159,7 +159,7 @@ impl<F> FnGraph<F> {
                         if predecessor_counts[child_fn_id.index()] == 0 {
                             if let Some(fn_ready_tx) = fn_ready_tx.as_ref() {
                                 fn_ready_tx.try_send(child_fn_id).unwrap_or_else(
-                                    #[cfg_attr(coverage_nightly, no_coverage)]
+                                    #[cfg_attr(coverage_nightly, coverage(off))]
                                     |e| {
                                         panic!(
                                             "Failed to queue function `{}`. Cause: {}",
@@ -579,7 +579,7 @@ impl<F> FnGraph<F> {
                             if predecessor_counts[child_fn_id.index()] == 0 {
                                 if let Some(fn_ready_tx) = fn_ready_tx.as_ref() {
                                     fn_ready_tx.try_send(child_fn_id).unwrap_or_else(
-                                        #[cfg_attr(coverage_nightly, no_coverage)]
+                                        #[cfg_attr(coverage_nightly, coverage(off))]
                                         |e| {
                                         panic!(
                                             "Failed to queue function `{}`. Cause: {}",
@@ -1604,7 +1604,7 @@ mod tests {
             fn_graph
                 .stream()
                 .for_each(
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async {},
                 )
                 .await;
@@ -1644,7 +1644,7 @@ mod tests {
             fn_graph
                 .stream_rev()
                 .for_each(
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async {},
                 )
                 .await;
@@ -1686,7 +1686,7 @@ mod tests {
             fn_graph
                 .fold_async(
                     (),
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |(), _f| Box::pin(async {}),
                 )
                 .await;
@@ -1726,7 +1726,7 @@ mod tests {
             fn_graph
                 .fold_rev_async(
                     (),
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |(), _f| Box::pin(async {}),
                 )
                 .await;
@@ -1767,7 +1767,7 @@ mod tests {
             fn_graph
                 .for_each_concurrent(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async {},
                 )
                 .await;
@@ -1810,7 +1810,7 @@ mod tests {
             fn_graph
                 .for_each_concurrent_rev(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async {},
                 )
                 .await;
@@ -1853,7 +1853,7 @@ mod tests {
             fn_graph
                 .try_for_each_concurrent(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async { Ok::<_, ()>(()) },
                 )
                 .await
@@ -2010,7 +2010,7 @@ mod tests {
             fn_graph
                 .try_for_each_concurrent_rev(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async { Ok::<_, ()>(()) },
                 )
                 .await
@@ -2503,7 +2503,7 @@ mod tests {
             let (ControlFlow::Continue(()) | ControlFlow::Break(())) = fn_graph
                 .try_for_each_concurrent_control(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async { ControlFlow::Continue(()) },
                 )
                 .await;
@@ -2650,7 +2650,7 @@ mod tests {
             let (ControlFlow::Continue(()) | ControlFlow::Break(())) = fn_graph
                 .try_for_each_concurrent_control_rev(
                     None,
-                    #[cfg_attr(coverage_nightly, no_coverage)]
+                    #[cfg_attr(coverage_nightly, coverage(off))]
                     |_f| async { ControlFlow::Continue(()) },
                 )
                 .await;
@@ -3303,7 +3303,7 @@ mod tests {
         struct TestError(&'static str);
 
         impl fmt::Display for TestError {
-            #[cfg_attr(coverage_nightly, no_coverage)]
+            #[cfg_attr(coverage_nightly, coverage(off))]
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 self.0.fmt(f)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@
 //! fn_graph = "0.8.1"
 //!
 //! # Integrate with `fn_meta` and/or `resman`
-//! fn_graph = { version = "0.8.4", features = ["fn_meta"] }
-//! fn_graph = { version = "0.8.4", features = ["resman"] }
-//! fn_graph = { version = "0.8.4", features = ["fn_meta", "resman"] }
+//! fn_graph = { version = "0.8.5", features = ["fn_meta"] }
+//! fn_graph = { version = "0.8.5", features = ["resman"] }
+//! fn_graph = { version = "0.8.5", features = ["fn_meta", "resman"] }
 //! ```
 //!
 //! # Rationale

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 //! Dynamically managed function graph execution.
 //!


### PR DESCRIPTION
Also updates coverage attribute due to `cargo-llvm-version` upgrade.

Bumps crate to `0.8.5`.