### PR TITLE
Add `StreamOutcome::replace_with`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## unreleased
+
+* Add `StreamOutcome::replace_with`.
+
+
 ## 0.9.0 (2023-11-28)
 
-* Add `interruptible` support` with `features = ["interruptible"]`.
+* Add `interruptible` support with `features = ["interruptible"]`.
 * Add `StreamOpts` to specify streaming options.
 * Add `FnGraph::stream_with`.
 * Add `FnGraph::fold_async_with`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fn_graph"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Dynamically managed function graph execution."

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ closures and functions, but any type that implements the [`FnRes`] and
 Add the following to `Cargo.toml`
 
 ```toml
-fn_graph = "0.9.0"
+fn_graph = "0.9.1"
 
 # Integrate with `fn_meta` / `interruptible` / `resman`
-fn_graph = { version = "0.9.0", features = ["fn_meta"] }
-fn_graph = { version = "0.9.0", features = ["interruptible"] }
-fn_graph = { version = "0.9.0", features = ["resman"] }
-fn_graph = { version = "0.9.0", features = ["fn_meta", "interruptible", "resman"] }
+fn_graph = { version = "0.9.1", features = ["fn_meta"] }
+fn_graph = { version = "0.9.1", features = ["interruptible"] }
+fn_graph = { version = "0.9.1", features = ["resman"] }
+fn_graph = { version = "0.9.1", features = ["fn_meta", "interruptible", "resman"] }
 ```
 
 # Rationale

--- a/src/fn_graph.rs
+++ b/src/fn_graph.rs
@@ -1664,9 +1664,7 @@ impl<F> FnGraph<F> {
     /// Returns an iterator of function references in insertion order.
     ///
     /// To iterate in logical dependency order, see [`FnGraph::iter`].
-    pub fn iter_insertion(
-        &self,
-    ) -> impl Iterator<Item = &F> + ExactSizeIterator + DoubleEndedIterator {
+    pub fn iter_insertion(&self) -> impl ExactSizeIterator<Item = &F> + DoubleEndedIterator {
         use daggy::petgraph::visit::IntoNodeReferences;
         self.graph.node_references().map(|(_, function)| function)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@
 //! Add the following to `Cargo.toml`
 //!
 //! ```toml
-//! fn_graph = "0.9.0"
+//! fn_graph = "0.9.1"
 //!
 //! # Integrate with `fn_meta` / `interruptible` / `resman`
-//! fn_graph = { version = "0.9.0", features = ["fn_meta"] }
-//! fn_graph = { version = "0.9.0", features = ["interruptible"] }
-//! fn_graph = { version = "0.9.0", features = ["resman"] }
-//! fn_graph = { version = "0.9.0", features = ["fn_meta", "interruptible", "resman"] }
+//! fn_graph = { version = "0.9.1", features = ["fn_meta"] }
+//! fn_graph = { version = "0.9.1", features = ["interruptible"] }
+//! fn_graph = { version = "0.9.1", features = ["resman"] }
+//! fn_graph = { version = "0.9.1", features = ["fn_meta", "interruptible", "resman"] }
 //! ```
 //!
 //! # Rationale


### PR DESCRIPTION
Allows users to extract a value from `StreamOutcome`.

Also bumps the crate version to `0.9.1`.