### PR TITLE
Actually populate `fn_ids_not_processed`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## 0.10.0 (2023-12-28)
 
 * Replace `StreamProgress::{empty, with_capacity}` with `StreamProgress::new`.
 * Actually return values in `StreamOutcome::fn_ids_not_processed`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+* Replace `StreamProgress::{empty, with_capacity}` with `StreamProgress::new`.
+* Actually return values in `StreamOutcome::fn_ids_not_processed`.
+
+
 ## 0.9.1 (2023-12-14)
 
 * Add `StreamOutcome::replace_with`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,16 @@ daggy = { version = "0.8.0", default-features = false }
 fn_meta = { version = "0.7.3", optional = true, features = ["fn_meta_ext"] }
 interruptible = { version = "0.0.3", optional = true, features = ["stream"] }
 resman = { version = "0.17.0", optional = true, features = ["debug"] }
-futures = { version = "0.3.29", optional = true }
+futures = { version = "0.3.30", optional = true }
 smallvec = "1.11.2"
-tokio = { version = "1.34.0", features = ["sync"] }
+tokio = { version = "1.35.1", features = ["sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.89"
 
 [dev-dependencies]
 resman = { version = "0.17.0", features = ["debug", "fn_res", "fn_res_mut", "fn_meta"] }
-tokio = { version = "1.34.0", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1.35.1", features = ["macros", "rt", "sync", "time"] }
 
 [features]
 default = ["async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fn_graph"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Dynamically managed function graph execution."

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ closures and functions, but any type that implements the [`FnRes`] and
 Add the following to `Cargo.toml`
 
 ```toml
-fn_graph = "0.9.1"
+fn_graph = "0.10.0"
 
 # Integrate with `fn_meta` / `interruptible` / `resman`
-fn_graph = { version = "0.9.1", features = ["fn_meta"] }
-fn_graph = { version = "0.9.1", features = ["interruptible"] }
-fn_graph = { version = "0.9.1", features = ["resman"] }
-fn_graph = { version = "0.9.1", features = ["fn_meta", "interruptible", "resman"] }
+fn_graph = { version = "0.10.0", features = ["fn_meta"] }
+fn_graph = { version = "0.10.0", features = ["interruptible"] }
+fn_graph = { version = "0.10.0", features = ["resman"] }
+fn_graph = { version = "0.10.0", features = ["fn_meta", "interruptible", "resman"] }
 ```
 
 # Rationale

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@
 //! Add the following to `Cargo.toml`
 //!
 //! ```toml
-//! fn_graph = "0.9.1"
+//! fn_graph = "0.10.0"
 //!
 //! # Integrate with `fn_meta` / `interruptible` / `resman`
-//! fn_graph = { version = "0.9.1", features = ["fn_meta"] }
-//! fn_graph = { version = "0.9.1", features = ["interruptible"] }
-//! fn_graph = { version = "0.9.1", features = ["resman"] }
-//! fn_graph = { version = "0.9.1", features = ["fn_meta", "interruptible", "resman"] }
+//! fn_graph = { version = "0.10.0", features = ["fn_meta"] }
+//! fn_graph = { version = "0.10.0", features = ["interruptible"] }
+//! fn_graph = { version = "0.10.0", features = ["resman"] }
+//! fn_graph = { version = "0.10.0", features = ["fn_meta", "interruptible", "resman"] }
 //! ```
 //!
 //! # Rationale

--- a/src/stream_progress.rs
+++ b/src/stream_progress.rs
@@ -14,23 +14,14 @@ pub struct StreamProgress<T> {
 }
 
 impl<T> StreamProgress<T> {
-    /// Returns an empty `FnGraphStreamOutcome`.
-    pub fn empty(value: T) -> Self {
+    /// Returns a new `FnGraphStreamProgress` with IDs of the functions to
+    /// process.
+    pub fn new(value: T, fn_ids_not_processed: Vec<FnId>) -> Self {
         Self {
             value,
             state: StreamProgressState::NotStarted,
-            fn_ids_processed: Vec::new(),
-            fn_ids_not_processed: Vec::new(),
-        }
-    }
-
-    /// Returns an empty `FnGraphStreamProgress` with the given capacity.
-    pub fn with_capacity(value: T, capacity: usize) -> Self {
-        Self {
-            value,
-            state: StreamProgressState::NotStarted,
-            fn_ids_processed: Vec::with_capacity(capacity),
-            fn_ids_not_processed: Vec::with_capacity(capacity),
+            fn_ids_processed: Vec::with_capacity(fn_ids_not_processed.len()),
+            fn_ids_not_processed,
         }
     }
 


### PR DESCRIPTION
Also updates crate version to `0.10.0`.