### PR TITLE
Use `daggy` instead of `daggy2`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.0 (2025-02-22)
+
+* Switch from `daggy2` to `daggy`.
+
+
 ## 0.15.0 (2025-01-12)
 
 * Update `resman` from `0.17.0` to `0.18.0`.
@@ -8,6 +13,7 @@
 ## 0.14.0 (2025-01-11)
 
 * Update dependency versions.
+* Switch from `daggy` to `daggy2`.
 
 
 ## 0.13.3 (2024-08-31)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ fn_meta = { version = "0.7.4", optional = true, features = ["fn_meta_ext"] }
 interruptible = { version = "0.2.4", optional = true, features = ["stream"] }
 resman = { version = "0.18", optional = true, features = ["debug"] }
 futures = { version = "0.3.31", optional = true }
-serde = { version = "1.0.217", optional = true, features = ["derive"] }
-smallvec = "1.13"
+serde = { version = "1.0.218", optional = true, features = ["derive"] }
+smallvec = "1.14"
 tokio = { version = "1.43", features = ["sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.99"
+wasm-bindgen = "0.2.100"
 
 [dev-dependencies]
 resman = { version = "0.18", features = ["debug", "fn_res", "fn_res_mut", "fn_meta"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fn_graph"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Runs interdependent logic concurrently, starting each function when predecessors have completed."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-daggy2 = { version = "0.8.1", default-features = false }
+daggy = { version = "0.8.1", default-features = false }
 fixedbitset = "0.5.7"
 fn_meta = { version = "0.7.4", optional = true, features = ["fn_meta_ext"] }
 interruptible = { version = "0.2.4", optional = true, features = ["stream"] }
@@ -35,7 +35,7 @@ serde_yaml = "0.9.34"
 [features]
 default = ["async"]
 async = ["futures"]
-graph_info = ["dep:serde", "daggy2/serde-1"]
+graph_info = ["dep:serde", "daggy/serde-1"]
 interruptible = ["dep:interruptible"]
 fn_res = ["resman?/fn_res"]
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ closures and functions, but any type that implements the [`FnRes`] and
 Add the following to `Cargo.toml`
 
 ```toml
-fn_graph = "0.15.0"
+fn_graph = "0.16.0"
 
 # Integrate with `fn_meta` / `interruptible` / `resman`
-fn_graph = { version = "0.15.0", features = ["fn_meta"] }
-fn_graph = { version = "0.15.0", features = ["interruptible"] }
-fn_graph = { version = "0.15.0", features = ["resman"] }
-fn_graph = { version = "0.15.0", features = ["fn_meta", "interruptible", "resman"] }
+fn_graph = { version = "0.16.0", features = ["fn_meta"] }
+fn_graph = { version = "0.16.0", features = ["interruptible"] }
+fn_graph = { version = "0.16.0", features = ["resman"] }
+fn_graph = { version = "0.16.0", features = ["fn_meta", "interruptible", "resman"] }
 ```
 
 # Rationale

--- a/src/edge_id.rs
+++ b/src/edge_id.rs
@@ -1,4 +1,4 @@
-use daggy2::EdgeIndex;
+use daggy::EdgeIndex;
 
 use crate::FnIdInner;
 

--- a/src/fn_graph.rs
+++ b/src/fn_graph.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{ControlFlow, Deref, DerefMut},
 };
 
-use daggy2::{
+use daggy::{
     petgraph::{graph::NodeReferences, visit::Topo},
     Dag, NodeWeightsMut, Walker,
 };
@@ -12,7 +12,7 @@ use fixedbitset::FixedBitSet;
 use crate::{Edge, FnId, FnIdInner, Rank};
 
 #[cfg(feature = "async")]
-use daggy2::NodeIndex;
+use daggy::NodeIndex;
 #[cfg(feature = "async")]
 use futures::future::LocalBoxFuture;
 #[cfg(feature = "async")]
@@ -1896,7 +1896,7 @@ impl<F> FnGraph<F> {
     ///
     /// To iterate in logical dependency order, see [`FnGraph::iter`].
     pub fn iter_insertion(&self) -> impl ExactSizeIterator<Item = &F> + DoubleEndedIterator {
-        use daggy2::petgraph::visit::IntoNodeReferences;
+        use daggy::petgraph::visit::IntoNodeReferences;
         self.graph.node_references().map(|(_, function)| function)
     }
 
@@ -1911,7 +1911,7 @@ impl<F> FnGraph<F> {
     ///
     /// Each iteration returns a `(FnId, &'a F)`.
     pub fn iter_insertion_with_indices(&self) -> NodeReferences<F, FnIdInner> {
-        use daggy2::petgraph::visit::IntoNodeReferences;
+        use daggy::petgraph::visit::IntoNodeReferences;
         self.graph.node_references()
     }
 }
@@ -2370,7 +2370,7 @@ impl<F> Eq for FnGraph<F> where F: Eq {}
 #[cfg(feature = "fn_meta")]
 #[cfg(test)]
 mod tests {
-    use daggy2::WouldCycle;
+    use daggy::WouldCycle;
     use resman::{FnRes, IntoFnRes, Resources};
 
     use super::FnGraph;
@@ -2672,7 +2672,7 @@ mod tests {
     mod async_tests {
         use std::{fmt, ops::ControlFlow};
 
-        use daggy2::{NodeIndex, WouldCycle};
+        use daggy::{NodeIndex, WouldCycle};
         use futures::{future::BoxFuture, stream, Future, FutureExt, StreamExt};
         use resman::{FnRes, FnResMut, IntoFnRes, IntoFnResMut, Resources};
         use tokio::{

--- a/src/fn_graph_builder.rs
+++ b/src/fn_graph_builder.rs
@@ -1,4 +1,4 @@
-use daggy2::{Dag, WouldCycle};
+use daggy::{Dag, WouldCycle};
 
 use crate::{DataAccessDyn, Edge, EdgeId, FnGraph, FnId, FnIdInner};
 
@@ -62,7 +62,7 @@ where
     /// multiple times with the same functions, only the last call's edge
     /// will be retained.
     ///
-    /// [`add_edge`]: daggy2::petgraph::data::Build::add_edge
+    /// [`add_edge`]: daggy::petgraph::data::Build::add_edge
     pub fn add_logic_edge(
         &mut self,
         function_from: FnId,
@@ -81,7 +81,7 @@ where
     /// multiple times with the same functions, only the last call's edge
     /// will be retained.
     ///
-    /// [`add_edge`]: daggy2::petgraph::data::Build::add_edge
+    /// [`add_edge`]: daggy::petgraph::data::Build::add_edge
     pub fn add_contains_edge(
         &mut self,
         function_from: FnId,
@@ -176,7 +176,7 @@ impl<F> Default for FnGraphBuilder<F> {
 #[cfg(feature = "fn_meta")]
 #[cfg(test)]
 mod tests {
-    use daggy2::WouldCycle;
+    use daggy::WouldCycle;
     use resman::IntoFnRes;
 
     use super::FnGraphBuilder;

--- a/src/fn_graph_builder/data_edge_augmenter.rs
+++ b/src/fn_graph_builder/data_edge_augmenter.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use daggy2::{petgraph::algo::has_path_connecting, Dag};
+use daggy::{petgraph::algo::has_path_connecting, Dag};
 
 use crate::{DataAccessDyn, Edge, FnId, FnIdInner, Rank};
 
@@ -92,7 +92,7 @@ where
 #[cfg(feature = "fn_meta")]
 #[cfg(test)]
 mod tests {
-    use daggy2::{petgraph::algo::all_simple_paths, Dag, WouldCycle};
+    use daggy::{petgraph::algo::all_simple_paths, Dag, WouldCycle};
     use resman::{FnRes, IntoFnRes};
 
     use super::{super::RankCalc, DataEdgeAugmenter};

--- a/src/fn_graph_builder/predecessor_count_calc.rs
+++ b/src/fn_graph_builder/predecessor_count_calc.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use daggy2::{Dag, Walker};
+use daggy::{Dag, Walker};
 
 use crate::{Edge, EdgeCounts, FnIdInner};
 
@@ -38,7 +38,7 @@ impl<F> PredecessorCountCalc<F> {
 
 #[cfg(test)]
 mod tests {
-    use daggy2::{Dag, WouldCycle};
+    use daggy::{Dag, WouldCycle};
     use resman::IntoFnRes;
 
     use super::PredecessorCountCalc;

--- a/src/fn_graph_builder/rank_calc.rs
+++ b/src/fn_graph_builder/rank_calc.rs
@@ -1,6 +1,6 @@
 use std::{cmp, collections::VecDeque, marker::PhantomData};
 
-use daggy2::{petgraph::visit::IntoNodeReferences, Dag, Walker};
+use daggy::{petgraph::visit::IntoNodeReferences, Dag, Walker};
 
 use crate::{Edge, FnId, FnIdInner, Rank};
 
@@ -58,7 +58,7 @@ impl<F> RankCalc<F> {
 
 #[cfg(test)]
 mod tests {
-    use daggy2::{Dag, WouldCycle};
+    use daggy::{Dag, WouldCycle};
     use resman::IntoFnRes;
 
     use super::RankCalc;

--- a/src/fn_id.rs
+++ b/src/fn_id.rs
@@ -1,4 +1,4 @@
-use daggy2::NodeIndex;
+use daggy::NodeIndex;
 
 use crate::FnIdInner;
 

--- a/src/fn_id_inner.rs
+++ b/src/fn_id_inner.rs
@@ -1,4 +1,4 @@
-use daggy2::petgraph::graph::IndexType;
+use daggy::petgraph::graph::IndexType;
 
 /// Type safe function ID for a `FnGraph`.
 #[cfg_attr(feature = "graph_info", derive(serde::Deserialize, serde::Serialize))]

--- a/src/graph_info.rs
+++ b/src/graph_info.rs
@@ -1,4 +1,4 @@
-use daggy2::{
+use daggy::{
     petgraph::{
         graph::NodeReferences,
         visit::{Reversed, Topo},
@@ -84,7 +84,7 @@ impl<NodeInfo> GraphInfo<NodeInfo> {
     ///
     /// Each iteration returns a `(FnId, &'a F)`.
     pub fn iter_insertion_with_indices(&self) -> NodeReferences<NodeInfo, FnIdInner> {
-        use daggy2::petgraph::visit::IntoNodeReferences;
+        use daggy::petgraph::visit::IntoNodeReferences;
         self.graph.node_references()
     }
 }
@@ -124,7 +124,7 @@ impl<NodeInfo> Eq for GraphInfo<NodeInfo> where NodeInfo: Eq {}
 #[cfg(feature = "fn_meta")]
 #[cfg(test)]
 mod tests {
-    use daggy2::{petgraph::visit::IntoNodeReferences, WouldCycle};
+    use daggy::{petgraph::visit::IntoNodeReferences, WouldCycle};
     use resman::{FnRes, IntoFnRes, Resources};
 
     use super::GraphInfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,13 @@
 //! Add the following to `Cargo.toml`
 //!
 //! ```toml
-//! fn_graph = "0.15.0"
+//! fn_graph = "0.16.0"
 //!
 //! # Integrate with `fn_meta` / `interruptible` / `resman`
-//! fn_graph = { version = "0.15.0", features = ["fn_meta"] }
-//! fn_graph = { version = "0.15.0", features = ["interruptible"] }
-//! fn_graph = { version = "0.15.0", features = ["resman"] }
-//! fn_graph = { version = "0.15.0", features = ["fn_meta", "interruptible", "resman"] }
+//! fn_graph = { version = "0.16.0", features = ["fn_meta"] }
+//! fn_graph = { version = "0.16.0", features = ["interruptible"] }
+//! fn_graph = { version = "0.16.0", features = ["resman"] }
+//! fn_graph = { version = "0.16.0", features = ["fn_meta", "interruptible", "resman"] }
 //! ```
 //!
 //! # Rationale

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! [`FnMeta`]: https://docs.rs/fn_meta/latest/fn_meta/trait.FnMeta.html
 //! [`FnRes`]: https://docs.rs/resman/latest/resman/trait.FnRes.html
 
-pub use daggy2::{self, WouldCycle};
+pub use daggy::{self, WouldCycle};
 
 #[cfg(feature = "resman")]
 pub use resman::{self, Resources};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@
 //!   `fn_graph` keeps a dependency graph of logic and data dependencies, and
 //!   executes functions when the preceding functions are complete.
 //!
-//!     This allows for slightly less waiting time for subsequent functions with
-//!     data dependencies, as each may begin once its predecessors finish,
-//!     whereas a staged approach may contain other functions that are still
-//!     executing that prevent functions in the next stage from beginning
-//!     execution.
+//!   This allows for slightly less waiting time for subsequent functions with
+//!   data dependencies, as each may begin once its predecessors finish,
+//!   whereas a staged approach may contain other functions that are still
+//!   executing that prevent functions in the next stage from beginning
+//!   execution.
 //!
 //! ## See Also
 //!

--- a/src/stream_outcome.rs
+++ b/src/stream_outcome.rs
@@ -1,4 +1,4 @@
-use daggy2::{petgraph::visit::IntoNodeReferences, Dag};
+use daggy::{petgraph::visit::IntoNodeReferences, Dag};
 
 use crate::{Edge, FnId, FnIdInner};
 


### PR DESCRIPTION
`daggy` is now up to date, so let's use that.